### PR TITLE
Add optional file argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,15 @@
 
 Extract html based on css selector.
 
-## Example
+## Examples
 
 ### File
 
 ```
- cargo run -- "div > h1" < example.html
+ cargo run -- "div > h1" example.html
 ```
 
-### Curl
+### Pipe (Curl)
 ```
 curl -sL -H "User-Agent: hq" http://example.com | cargo run -- "div > h1"
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use scraper::{Html, Selector};
 use std::io::{self, BufRead};
-use structopt::StructOpt;
 use std::path::PathBuf;
+use structopt::StructOpt;
 
 #[derive(Debug, StructOpt)]
 struct Args {
@@ -29,7 +29,7 @@ fn get_html(file: &Option<PathBuf>) -> Html {
 
 fn get_content(file: &Option<PathBuf>) -> String {
     match file {
-        Some(ref file) =>  read_from_file(file),
+        Some(ref file) => read_from_file(file),
         None => read_from_stdin(),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,28 +1,55 @@
 use scraper::{Html, Selector};
 use std::io::{self, BufRead};
 use structopt::StructOpt;
+use std::path::PathBuf;
 
 #[derive(Debug, StructOpt)]
 struct Args {
     selectors: String,
+    #[structopt(parse(from_os_str))]
+    file: Option<PathBuf>,
 }
 
 fn main() {
     let args = Args::from_args();
-    let selector = Selector::parse(&args.selectors).unwrap();
 
-    let content: String = {
-        let stdin = io::stdin();
-        stdin
-            .lock()
-            .lines()
-            .filter_map(|l| l.ok())
-            .collect::<Vec<String>>()
-            .join("")
-    };
+    let selector = get_selector(&args.selectors);
+    let html = get_html(&args.file);
+    extract(&selector, html)
+}
 
-    let document = Html::parse_fragment(&content);
-    for element in document.select(&selector) {
+fn get_selector(selectors: &str) -> Selector {
+    Selector::parse(selectors).unwrap()
+}
+
+fn get_html(file: &Option<PathBuf>) -> Html {
+    let fragment = get_content(file);
+    Html::parse_fragment(&fragment)
+}
+
+fn get_content(file: &Option<PathBuf>) -> String {
+    match file {
+        Some(ref file) =>  read_from_file(file),
+        None => read_from_stdin(),
+    }
+}
+
+fn read_from_file(path: &PathBuf) -> String {
+    std::fs::read_to_string(path).unwrap()
+}
+
+fn read_from_stdin() -> String {
+    let stdin = io::stdin();
+    stdin
+        .lock()
+        .lines()
+        .filter_map(|l| l.ok())
+        .collect::<Vec<String>>()
+        .join("")
+}
+
+fn extract(selector: &Selector, html: Html) {
+    for element in html.select(&selector) {
         println!("{:?}", element.html());
     }
 }


### PR DESCRIPTION
Add optional `file` argument to simplify the experience of reading html from a file. 

Before a user would have to `cargo run -- "div > h1" < example.html`. Now they can `cargo run -- "div > h1" example.html`. 

In addition, `file` will now be output in the help. When help messaging is added, this argument should prove helpful to users trying to understand the usage of the tool.