### PR TITLE
Output (more) human friendly errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
+name = "backtrace"
+version = "0.3.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
+dependencies = [
+ "backtrace-sys",
+ "cfg-if",
+ "libc",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "backtrace-sys"
+version = "0.1.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18fbebbe1c9d1f383a9cc7e8ccdb471b91c8d024ee9c2ca5b5346121fe8b4399"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -37,6 +59,12 @@ name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+
+[[package]]
+name = "cc"
+version = "1.0.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d"
 
 [[package]]
 name = "cfg-if"
@@ -122,6 +150,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a68a4904193147e0a8dec3314640e6db742afd5f6e634f428a6af230d9b3591"
 
 [[package]]
+name = "exitfailure"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ff5bd832af37f366c6c194d813a11cd90ac484f124f079294f28e357ae40515"
+dependencies = [
+ "failure",
+]
+
+[[package]]
+name = "failure"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
+dependencies = [
+ "backtrace",
+ "failure_derive",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -177,7 +236,11 @@ dependencies = [
 name = "hq"
 version = "0.1.0"
 dependencies = [
+ "cssparser",
+ "exitfailure",
+ "failure",
  "scraper",
+ "selectors",
  "structopt",
 ]
 
@@ -479,6 +542,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
+
+[[package]]
 name = "ryu"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -662,6 +731,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9a60d744a80c30fcb657dfe2c1b22bcb3e814c1a1e3674f32bf5820b570fbff"
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,28 +33,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d49d90015b3c36167a20fe2810c5cd875ad504b39cff3d4eae7977e6b7c1cb2"
 
 [[package]]
-name = "backtrace"
-version = "0.3.46"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e692897359247cc6bb902933361652380af0f1b7651ae5c5013407f30e109e"
-dependencies = [
- "backtrace-sys",
- "cfg-if",
- "libc",
- "rustc-demangle",
-]
-
-[[package]]
-name = "backtrace-sys"
-version = "0.1.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18fbebbe1c9d1f383a9cc7e8ccdb471b91c8d024ee9c2ca5b5346121fe8b4399"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,12 +43,6 @@ name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
-
-[[package]]
-name = "cc"
-version = "1.0.52"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d87b23d6a92cd03af510a5ade527033f6aa6fa92161e2d5863a907d4c5e31d"
 
 [[package]]
 name = "cfg-if"
@@ -150,37 +128,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a68a4904193147e0a8dec3314640e6db742afd5f6e634f428a6af230d9b3591"
 
 [[package]]
-name = "exitfailure"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ff5bd832af37f366c6c194d813a11cd90ac484f124f079294f28e357ae40515"
-dependencies = [
- "failure",
-]
-
-[[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "fuchsia-cprng"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -236,9 +183,8 @@ dependencies = [
 name = "hq"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "cssparser",
- "exitfailure",
- "failure",
  "scraper",
  "selectors",
  "structopt",
@@ -542,12 +488,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-demangle"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
-
-[[package]]
 name = "ryu"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -731,18 +671,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "unicode-xid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,9 @@ authors = ["ozbe <1372945+ozbe@users.noreply.github.com>"]
 edition = "2018"
 
 [dependencies]
+cssparser = "0.25.9"
+failure = "0.1.8"
+exitfailure = "0.5.1"
 scraper = "0.11.0"
+selectors = "0.21.0"
 structopt = "0.3.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,8 @@ authors = ["ozbe <1372945+ozbe@users.noreply.github.com>"]
 edition = "2018"
 
 [dependencies]
+anyhow = "1.0.28"
 cssparser = "0.25.9"
-failure = "0.1.8"
-exitfailure = "0.5.1"
 scraper = "0.11.0"
 selectors = "0.21.0"
 structopt = "0.3.12"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,9 @@
+use anyhow::{Context, Result};
 use cssparser::{BasicParseErrorKind, ParseErrorKind};
-use exitfailure::ExitFailure;
-use failure::ResultExt;
-use failure::_core::fmt::Formatter;
 use scraper::{Html, Selector};
 use selectors::parser::SelectorParseErrorKind;
 use std::error::Error;
-use std::fmt::Display;
+use std::fmt::{Display, Formatter};
 use std::io::{self, BufRead};
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -28,7 +26,7 @@ struct Args {
     file: Option<PathBuf>,
 }
 
-fn main() -> Result<(), ExitFailure> {
+fn main() -> Result<()> {
     let args = Args::from_args();
 
     let selector = get_selector(&args.selectors)?;
@@ -38,28 +36,28 @@ fn main() -> Result<(), ExitFailure> {
     Ok(())
 }
 
-fn get_selector(selectors: &str) -> Result<Selector, failure::Error> {
+fn get_selector(selectors: &str) -> Result<Selector> {
     Selector::parse(selectors)
         .map_err(ParseError::from)
-        .with_context(|_| format!("could not parse selectors `{}`", selectors))
+        .with_context(|| format!("could not parse selectors `{}`", selectors))
         .map_err(From::from)
 }
 
-fn get_html(file: &Option<PathBuf>) -> Result<Html, failure::Error> {
+fn get_html(file: &Option<PathBuf>) -> Result<Html> {
     let fragment = get_content(file)?;
     Ok(Html::parse_fragment(&fragment))
 }
 
-fn get_content(file: &Option<PathBuf>) -> Result<String, failure::Error> {
+fn get_content(file: &Option<PathBuf>) -> Result<String> {
     match file {
         Some(ref file) => read_from_file(file),
         None => Ok(read_from_stdin()),
     }
 }
 
-fn read_from_file(path: &PathBuf) -> Result<String, failure::Error> {
+fn read_from_file(path: &PathBuf) -> Result<String> {
     std::fs::read_to_string(path)
-        .with_context(|_| format!("could not read file `{}`", path.as_path().display()))
+        .with_context(|| format!("could not read file `{}`", path.as_path().display()))
         .map_err(From::from)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,7 +38,7 @@ fn main() -> Result<()> {
 
 fn get_selector(selectors: &str) -> Result<Selector> {
     Selector::parse(selectors)
-        .map_err(ParseError::from)
+        .map_err(SelectorParseError::from)
         .with_context(|| format!("could not parse selectors `{}`", selectors))
         .map_err(From::from)
 }
@@ -78,15 +78,15 @@ fn extract(selector: &Selector, html: Html) {
 }
 
 #[derive(Debug)]
-struct ParseError(String);
+struct SelectorParseError(String);
 
-impl Display for ParseError {
+impl Display for SelectorParseError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         self.0.fmt(f)
     }
 }
 
-impl<'i> From<cssparser::ParseError<'i, SelectorParseErrorKind<'i>>> for ParseError {
+impl<'i> From<cssparser::ParseError<'i, SelectorParseErrorKind<'i>>> for SelectorParseError {
     fn from(e: cssparser::ParseError<'i, SelectorParseErrorKind<'i>>) -> Self {
         let msg = match e.kind {
             ParseErrorKind::Basic(b) => match b {
@@ -154,8 +154,8 @@ impl<'i> From<cssparser::ParseError<'i, SelectorParseErrorKind<'i>>> for ParseEr
                 SelectorParseErrorKind::EmptyNegation => "empty negation".to_string(),
             },
         };
-        ParseError(msg)
+        SelectorParseError(msg)
     }
 }
 
-impl Error for ParseError {}
+impl Error for SelectorParseError {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,11 @@
+use cssparser::{BasicParseErrorKind, ParseErrorKind};
+use exitfailure::ExitFailure;
+use failure::ResultExt;
+use failure::_core::fmt::Formatter;
 use scraper::{Html, Selector};
+use selectors::parser::SelectorParseErrorKind;
+use std::error::Error;
+use std::fmt::Display;
 use std::io::{self, BufRead};
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -21,32 +28,39 @@ struct Args {
     file: Option<PathBuf>,
 }
 
-fn main() {
+fn main() -> Result<(), ExitFailure> {
     let args = Args::from_args();
 
-    let selector = get_selector(&args.selectors);
-    let html = get_html(&args.file);
-    extract(&selector, html)
+    let selector = get_selector(&args.selectors)?;
+    let html = get_html(&args.file)?;
+    extract(&selector, html);
+
+    Ok(())
 }
 
-fn get_selector(selectors: &str) -> Selector {
-    Selector::parse(selectors).unwrap()
+fn get_selector(selectors: &str) -> Result<Selector, failure::Error> {
+    Selector::parse(selectors)
+        .map_err(ParseError::from)
+        .with_context(|_| format!("could not parse selectors `{}`", selectors))
+        .map_err(From::from)
 }
 
-fn get_html(file: &Option<PathBuf>) -> Html {
-    let fragment = get_content(file);
-    Html::parse_fragment(&fragment)
+fn get_html(file: &Option<PathBuf>) -> Result<Html, failure::Error> {
+    let fragment = get_content(file)?;
+    Ok(Html::parse_fragment(&fragment))
 }
 
-fn get_content(file: &Option<PathBuf>) -> String {
+fn get_content(file: &Option<PathBuf>) -> Result<String, failure::Error> {
     match file {
         Some(ref file) => read_from_file(file),
-        None => read_from_stdin(),
+        None => Ok(read_from_stdin()),
     }
 }
 
-fn read_from_file(path: &PathBuf) -> String {
-    std::fs::read_to_string(path).unwrap()
+fn read_from_file(path: &PathBuf) -> Result<String, failure::Error> {
+    std::fs::read_to_string(path)
+        .with_context(|_| format!("could not read file `{}`", path.as_path().display()))
+        .map_err(From::from)
 }
 
 fn read_from_stdin() -> String {
@@ -64,3 +78,86 @@ fn extract(selector: &Selector, html: Html) {
         println!("{:?}", element.html());
     }
 }
+
+#[derive(Debug)]
+struct ParseError(String);
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl<'i> From<cssparser::ParseError<'i, SelectorParseErrorKind<'i>>> for ParseError {
+    fn from(e: cssparser::ParseError<'i, SelectorParseErrorKind<'i>>) -> Self {
+        let msg = match e.kind {
+            ParseErrorKind::Basic(b) => match b {
+                BasicParseErrorKind::UnexpectedToken(_) => "unexpected token".to_string(),
+                BasicParseErrorKind::EndOfInput => {
+                    "end of the input was encountered unexpectedly.".to_string()
+                }
+                BasicParseErrorKind::AtRuleInvalid(a) => format!("invalid `@` rule {}", a),
+                BasicParseErrorKind::AtRuleBodyInvalid => {
+                    "body of an '@' rule was invalid".to_string()
+                }
+                BasicParseErrorKind::QualifiedRuleInvalid => {
+                    "qualified rule was encountered that was invalid".to_string()
+                }
+            },
+            ParseErrorKind::Custom(kind) => match kind {
+                SelectorParseErrorKind::BadValueInAttr(_) => "bad value in attribute".to_string(),
+                SelectorParseErrorKind::PseudoElementInComplexSelector => {
+                    "pseudo element is complex selector".to_string()
+                }
+                SelectorParseErrorKind::NoQualifiedNameInAttributeSelector(_) => {
+                    "no qualified name in attribute selector".to_string()
+                }
+                SelectorParseErrorKind::EmptySelector => "empty selector".to_string(),
+                SelectorParseErrorKind::DanglingCombinator => "dangling combinator".to_string(),
+                SelectorParseErrorKind::NonSimpleSelectorInNegation => {
+                    "non simple selector in negation".to_string()
+                }
+                SelectorParseErrorKind::NonCompoundSelector => "non compound selector".to_string(),
+                SelectorParseErrorKind::NonPseudoElementAfterSlotted => {
+                    "non pseudo element after slotted".to_string()
+                }
+                SelectorParseErrorKind::InvalidPseudoElementAfterSlotted => {
+                    "invalid pseudo element after slotted".to_string()
+                }
+                SelectorParseErrorKind::UnexpectedTokenInAttributeSelector(_) => {
+                    "unexpected token in attribute selector".to_string()
+                }
+                SelectorParseErrorKind::PseudoElementExpectedColon(_) => {
+                    "pseudo element expected colon".to_string()
+                }
+                SelectorParseErrorKind::PseudoElementExpectedIdent(_) => {
+                    "pseudo element expected identity".to_string()
+                }
+                SelectorParseErrorKind::NoIdentForPseudo(_) => "no identity for pseudo".to_string(),
+                SelectorParseErrorKind::UnsupportedPseudoClassOrElement(s) => {
+                    format!("unsupported pseudo class or element `{}`", s)
+                }
+                SelectorParseErrorKind::UnexpectedIdent(s) => {
+                    format!("unexpected identity `{}`", s)
+                }
+                SelectorParseErrorKind::ExpectedNamespace(s) => {
+                    format!("expected namespace `{}`", s)
+                }
+                SelectorParseErrorKind::ExpectedBarInAttr(_) => {
+                    "expected bar in attribute".to_string()
+                }
+                SelectorParseErrorKind::InvalidQualNameInAttr(_) => {
+                    "invalid qualified name in attribute".to_string()
+                }
+                SelectorParseErrorKind::ExplicitNamespaceUnexpectedToken(_) => {
+                    "explicit namespace unexpected token".to_string()
+                }
+                SelectorParseErrorKind::ClassNeedsIdent(_) => "class needs identity".to_string(),
+                SelectorParseErrorKind::EmptyNegation => "empty negation".to_string(),
+            },
+        };
+        ParseError(msg)
+    }
+}
+
+impl Error for ParseError {}


### PR DESCRIPTION
Output (more) human friendly errors in an effort to better inform the user what has gone wrong, so their chances of correcting the issue are higher.

The code also no longer explicitly calls `unwrap`.

Functionality should remain the same, only error output will have now changed.